### PR TITLE
adição da regra whatsapp

### DIFF
--- a/commands.txt
+++ b/commands.txt
@@ -3,7 +3,7 @@
 3. Mandar: "Eu + Você, hoje" pra conversa do topo do seu whatsapp, se não o fizer, beba 3 doses e escolha alguém pra fazer.
 4. Teste de alguma coisa
 5. Beba 1 dose e lance uma moeda se cair cara vc faz uma pergunda objetiva para a  pessoa a sua esquerda caso seja coroa faca para pessoa a sua direita depois lance a moeda mais uma vez se o resultade se repetir a pessoa que voce fez a pergunta bebe 2 doses
-5
+6. Deixe a pessoa ao lado mexer no seu whatsapp por cinco minutos, se n fizer, beba 3 doses.
 6
 7
 8


### PR DESCRIPTION
adicionada regra número 6 que diz que a pessoa deve dar o celular aberto no whatsapp para a pessoa ao lado olhar por 5 minutos e se não o fizer beber 3 doses 